### PR TITLE
docs: use npx pod-install instead of manual pod install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install via [npm](https://www.npmjs.com/package/react-native-blurhash):
 
 ```sh
 npm i react-native-blurhash
-cd ios; pod install; cd ..
+npx pod-install
 ```
 
 <a href='https://ko-fi.com/F1F8CLXG' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi2.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>


### PR DESCRIPTION
This command is a bit easier and helps developers stay in the root directory of the project 🙂 

I could also update this to the following so it's a one-liner copy/paste situation

```sh
npm i react-native-blurhash && npx pod-install
```

Equivalent in yarn:

```sh
yarn add react-native-blurhash && yarn pod-install
```