### PR TITLE
Add support for tvOS

### DIFF
--- a/react-native-blurhash.podspec
+++ b/react-native-blurhash.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
   # optional - use expanded license entry instead:
   # s.license    = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "Marc Rousavy" => "marcrousavy@hotmail.com" }
-  s.platforms    = { :ios => "9.0" }
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
   s.source       = { :git => "https://github.com/mrousavy/react-native-blurhash.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,m,swift}"


### PR DESCRIPTION
This PR fixes the issue I have created https://github.com/mrousavy/react-native-blurhash/issues/137

The tvOS was not supporting the library because it wasn't able to install the pod.