### PR TITLE
Add missing gradle.properties to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "README.md",
     "android/src",
     "android/build.gradle",
+    "android/gradle.properties",
     "ios/Blurhash.xcodeproj/project.pbxproj",
     "ios/**/*.h",
     "ios/**/*.m",


### PR DESCRIPTION
Android build fails with `Could not find org.jetbrains.kotlin:kotlin-gradle-plugin:null.` if `kotlinVersion` is not set since the `gradle.properties` file which defines the default values is missing from npm files.

Fixes #138