### PR TITLE
Use older lifecycle runtime to support older react native versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,5 +119,5 @@ dependencies {
     // noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
 }


### PR DESCRIPTION
Older react native versions have their compile sdk set to something lower than 31 by default (via the template). However, 2.4.0 lifecycle required 31. As far as I can tell this library uses nothing specifically from 2.4.0 so downgrading will do no harm, but increase the user base.