### PR TITLE
Add React-RCTImage dependency

### DIFF
--- a/react-native-blurhash.podspec
+++ b/react-native-blurhash.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
+  s.dependency "React-RCTImage"
 end
 


### PR DESCRIPTION
Blurhash imports RCTImageLoader which is part of React-RCTImage. This fixes failing builds with use_frameworks! (cocoapods) enabled.