### PR TITLE
fix: Update BlurhashImageView Context argument to be non-nullable

### DIFF
--- a/android/src/main/java/com/mrousavy/blurhash/BlurhashImageView.kt
+++ b/android/src/main/java/com/mrousavy/blurhash/BlurhashImageView.kt
@@ -36,7 +36,7 @@ internal class BlurhashCache(private val _blurhash: String?, private val _decode
 
 const val USE_COSINES_CACHE = true
 
-class BlurhashImageView(context: Context?): androidx.appcompat.widget.AppCompatImageView(context) {
+class BlurhashImageView(context: Context): androidx.appcompat.widget.AppCompatImageView(context) {
     var blurhash: String? = null
     var decodeWidth = 32
     var decodeHeight = 32


### PR DESCRIPTION
Without this when building the app we see the following error: `Type mismatch: inferred type is Context? but Context was expected`