### PR TITLE
docs: Indicate Expo support constraints in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ npx pod-install
   </p>
 </div>
 
+## Expo
+
+✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+
 ## Example Workflow
 
 <table>


### PR DESCRIPTION
This PR adds a new section to README to make it clear to folks that this library won't work in Expo Go but works well with expo-dev-client. [We are trying to come up with some standard messaging](https://expo.notion.site/Documenting-Expo-support-in-READMEs-f250a20b4bd5472cab0757918cb21062) that we can include in READMEs popular react-native libraries so if think this is unclear or have some suggestions to improve it, let me know! If you're on board with this change then I can open PRs to your other repos as well.