### PR TITLE
docs: Fix Expo support formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ npx pod-install
 
 ## Expo
 
-✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
-❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+- ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+- ❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
 
 ## Example Workflow
 


### PR DESCRIPTION
Each sentence here is meant to be on separate lines, so I have moved this to bullets:

## Before

<img width="887" alt="image" src="https://user-images.githubusercontent.com/90494/172189827-013ab114-61e2-4ab0-bef8-0588a8b1accb.png">

## After

<img width="877" alt="image" src="https://user-images.githubusercontent.com/90494/172189927-84aabea4-9952-46c8-9462-3b539677ed76.png">

Sorry for the thrash :)