### PR TITLE
Add RCTImage as a dependency

### DIFF
--- a/react-native-blurhash.podspec
+++ b/react-native-blurhash.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
+  s.dependency "React-RCTImage"
 end
 


### PR DESCRIPTION
In Xcode, I was getting the error

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_RCTImageLoader", referenced from:
    objc-class-ref in BlurhasViewManager-9ac8a7bc9b506dbb533a457971fde5e1.o
```

Versions:

- Xcode 13.2.1
- macOS 11.6.8
- Host arch: Intel Core i7
- React Native: 0.66.4

This patch fixed the compilation error. Feel free to not accept this PR, I don't depend on it merged because I have a local patch-package.