### PR TITLE
Fix for tvOS

### DIFF
--- a/react-native-blurhash.podspec
+++ b/react-native-blurhash.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
+  s.swift_version = "5.0"
 end
 


### PR DESCRIPTION
Fix for error:
`react-native-blurhash-tvOS` does not specify a Swift version and none of the targets (`reactfin-tvOS` and `reactfin-tvOSTests`)