### PR TITLE
fix: add missing .mm files to npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"ios/Blurhash.xcodeproj/project.pbxproj",
 		"ios/**/*.h",
 		"ios/**/*.m",
+		"ios/**/*.mm",
 		"ios/**/*.swift",
 		"lib/commonjs",
 		"lib/module",


### PR DESCRIPTION
The .mm files are missing from the npm package, this explains the missing module errors

Fixes #186