### PR TITLE
Revert "fix: Fix types of createBlurhashFromImage (#193)"

### DIFF
--- a/android/src/main/java/com/mrousavy/blurhash/BlurhashModule.kt
+++ b/android/src/main/java/com/mrousavy/blurhash/BlurhashModule.kt
@@ -22,8 +22,8 @@ class BlurhashModule(reactContext: ReactApplicationContext) :
   @ReactMethod
   override fun createBlurhashFromImage(
       imageUri: String,
-      componentsX: Int,
-      componentsY: Int,
+      componentsX: Double,
+      componentsY: Double,
       promise: Promise
   ) {
     thread(true) {
@@ -44,7 +44,7 @@ class BlurhashModule(reactContext: ReactApplicationContext) :
               override fun onNewResultImpl(bitmap: Bitmap?) {
                 try {
                   if (dataSource.isFinished && bitmap != null) {
-                    val blurhash = BlurHashEncoder.encode(bitmap, componentsX, componentsY)
+                    val blurhash = BlurHashEncoder.encode(bitmap, componentsX.toInt(), componentsY.toInt())
                     promise.resolve(blurhash)
                   } else {
                     if (dataSource.failureCause != null) {

--- a/android/src/paper/java/com/mrousavy/blurhash/NativeBlurhashModuleSpec.java
+++ b/android/src/paper/java/com/mrousavy/blurhash/NativeBlurhashModuleSpec.java
@@ -34,7 +34,7 @@ public abstract class NativeBlurhashModuleSpec extends ReactContextBaseJavaModul
 
   @ReactMethod
   @DoNotStrip
-  public abstract void createBlurhashFromImage(String imageUri, int componentsX, int componentsY, Promise promise);
+  public abstract void createBlurhashFromImage(String imageUri, double componentsX, double componentsY, Promise promise);
 
   @ReactMethod
   @DoNotStrip


### PR DESCRIPTION
This reverts commit 06d5a404387f75886f8564c611eafb8f57968dff.

Turns out the change to codegen was reverted in RN 0.74.3 (https://github.com/facebook/react-native/commit/278823ecc5783d187339b0aeafaaea0f9cb96d4a).