### PR TITLE
fix: wrong params name of function encode in ios new arch #197

### DIFF
--- a/ios/BlurhashModule.mm
+++ b/ios/BlurhashModule.mm
@@ -41,8 +41,8 @@ RCT_EXPORT_METHOD(createBlurhashFromImage
   [self.impl createBlurhashFromImage:imageUri
                          componentsX:componentsX
                          componentsY:componentsY
-                            resolver:resolve
-                            rejecter:reject];
+                             resolve:resolve
+                              reject:reject];
 }
 
 RCT_EXPORT_METHOD(clearCosineCache)

--- a/ios/BlurhashModuleImpl.swift
+++ b/ios/BlurhashModuleImpl.swift
@@ -19,7 +19,7 @@ public final class BlurhashModuleImpl: NSObject {
     }
 
     @objc
-    public func createBlurhashFromImage(_ imageUri: String, componentsX: Int, componentsY: Int, resolver resolve: @escaping (String) -> Void, rejecter reject: @escaping (String, String, Error?) -> Void) {
+    public func createBlurhashFromImage(_ imageUri: String, componentsX: Int, componentsY: Int, resolve: @escaping (String) -> Void, reject: @escaping (String, String, Error?) -> Void) {
         let formattedUri = imageUri.trimmingCharacters(in: .whitespacesAndNewlines)
 
         DispatchQueue.global(qos: .utility).async {

--- a/src/specs/NativeBlurhashModule.ts
+++ b/src/specs/NativeBlurhashModule.ts
@@ -1,8 +1,8 @@
 import { type TurboModule, TurboModuleRegistry } from 'react-native';
-import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
-	createBlurhashFromImage: (imageUri: string, componentsX: Int32, componentsY: Int32) => Promise<string>;
+	createBlurhashFromImage: (imageUri: string, componentsX: Double, componentsY: Double) => Promise<string>;
 	clearCosineCache: () => void;
 }
 


### PR DESCRIPTION
Codegen generate a file with wrong params name (change original file from resolver & rejecter to resolve & reject, because ts Promise is difficult to declare resolver & rejecter) and wrong type (from int32 to double).