### PR TITLE
fix: react-native 0.77 build on Android

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/BlurhashViewManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/BlurhashViewManagerDelegate.java
@@ -12,9 +12,10 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
-import com.facebook.react.uimanager.BaseViewManagerInterface;
+import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.LayoutShadowNode;
 
-public class BlurhashViewManagerDelegate<T extends View, U extends BaseViewManagerInterface<T> & BlurhashViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
+public class BlurhashViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & BlurhashViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public BlurhashViewManagerDelegate(U viewManager) {
     super(viewManager);
   }


### PR DESCRIPTION
@mrousavy  Resolves https://github.com/mrousavy/react-native-blurhash/issues/201

**Note**
_I'm not that well versed in Java/Kotlin so this solution was taken from similar issues with react native 77 android support on [shopify flash-list](https://github.com/Shopify/flash-list/pull/1484) and [shopify react native skia](https://github.com/Shopify/react-native-skia/pull/2926)._