### PR TITLE
fix(ios): fix blurhash view empty on new arch bridgeless

### DIFF
--- a/ios/BlurhashViewManager.swift
+++ b/ios/BlurhashViewManager.swift
@@ -84,8 +84,14 @@ final class BlurhashViewWrapper: UIView, BlurhashViewDelegate {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // Called only on the old arch:
     override func reactSetFrame(_ frame: CGRect) {
         blurhashView.frame = frame
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews();
+      blurhashView.frame = self.bounds;
     }
 
     override func didSetProps(_: [String]!) {


### PR DESCRIPTION
On iOS I had the issue that a view would not show the blur hash.
The problem is that on new arch this component is rendered through the legacy interop layer which
1. Doesn't set the frame on init
2. Doesn't call `reactSetFrame`

I fixed this by updating the blurhash's frame on `layoutSubviews`

Reproduction:
```tsx
export default function App() {
  return (
    <Blurhash blurhash="LGFFaXYk^6#M@-5c,1J5@[or[Q6." style={{ flex: 1 }} />
  );
}
```

| Before | After |
|--------|--------|
| ![IMG_9D21CB223A44-1](https://github.com/user-attachments/assets/62198f63-22d5-468a-808a-1dd9234ef5bc) | <img width="1170" height="2532" alt="IMG_2234" src="https://github.com/user-attachments/assets/e3125a03-f1b5-40f7-a5e2-8a20a3d3fd44" /> | 

